### PR TITLE
fix(concrete dependency): =0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ z8z-ks=[]
 z16z-ks=[]
 
 [dependencies]
-concrete="^0.1"
+concrete="=0.1.5"
 colored="2.0.0"


### PR DESCRIPTION
The concrete dependency was not fixed, reason why with the new version it was not usable anymore.
This patch fixes the version to match the version used when developing this demo.