### PR TITLE
Updating demo to concrete 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ z8z-ks=[]
 z16z-ks=[]
 
 [dependencies]
-concrete="^0.1"
+concrete="0.1.11"
 colored="2.0.0"
+concrete-core="0.1.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 //! A module containing a generic demonstration of computations over encrypted Z/qZ numbers.
 use colored::Colorize;
 #[allow(unused)]
-use concrete::crypto_api::{LWEParams, LWE128_1024, LWE128_750, RLWE128_1024_1, RLWE128_2048_1};
+use concrete::lwe_params::{LWEParams, LWE128_1024, LWE128_750};
+use concrete::rlwe_params::{RLWE128_1024_1, RLWE128_2048_1};
 use std::convert::TryInto;
 
 #[macro_use]

--- a/src/zqz/ciphertext.rs
+++ b/src/zqz/ciphertext.rs
@@ -1,7 +1,10 @@
 //! A module containing a ciphertext structure.
 use crate::zqz;
 use crate::PARAMS;
-use concrete::crypto_api;
+use concrete::lwe::LWE;
+use concrete::encoder::Encoder;
+use concrete::lwe_bsk::LWEBSK;
+use concrete::lwe_ksk::LWEKSK;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 use std::rc::Rc;
 use zqz::keys::HomomorphicKey;
@@ -10,17 +13,17 @@ use zqz::max::Max;
 /// An encrypted message.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Ciphertext {
-    pub(super) ciphertext: crypto_api::LWE,
+    pub(super) ciphertext: LWE,
     pub(super) evaluation_key: Rc<HomomorphicKey>,
 }
 
 fn bs_ks<F: Fn(f64) -> f64>(
-    ciphertext: &crypto_api::LWE,
-    bootstrapping_key: &crypto_api::LWEBSK,
+    ciphertext: &LWE,
+    bootstrapping_key: &LWEBSK,
     func: F,
-    encoder: &crypto_api::Encoder,
-    keyswitching_key: &crypto_api::LWEKSK,
-) -> crypto_api::LWE {
+    encoder: &Encoder,
+    keyswitching_key: &LWEKSK,
+) -> LWE {
     let res = ciphertext
         .bootstrap_with_function(bootstrapping_key, func, encoder)
         .unwrap();
@@ -84,7 +87,7 @@ impl Add<usize> for &Ciphertext {
     type Output = Ciphertext;
 
     fn add(self, other: usize) -> Self::Output {
-        let res: crypto_api::LWE = self
+        let res: LWE = self
             .ciphertext
             .add_constant_dynamic_encoder(other as f64)
             .unwrap();
@@ -144,7 +147,7 @@ impl Sub<usize> for &Ciphertext {
     type Output = Ciphertext;
 
     fn sub(self, other: usize) -> Self::Output {
-        let res: crypto_api::LWE = self
+        let res: LWE = self
             .ciphertext
             .add_constant_dynamic_encoder(-(other as f64))
             .unwrap();

--- a/src/zqz/mod.rs
+++ b/src/zqz/mod.rs
@@ -1,5 +1,5 @@
 // A module allowing to perform encrypted computations on Z/qZ.
-use concrete::crypto_api;
+
 
 pub mod ciphertext;
 pub mod keys;
@@ -18,8 +18,8 @@ pub struct Parameters {
     pub bs_level: usize,
     pub ks_base_log: usize,
     pub ks_level: usize,
-    pub rlwe_setting: crypto_api::RLWEParams,
-    pub lwe_setting: crypto_api::LWEParams,
+    pub rlwe_setting: concrete::rlwe_params::RLWEParams,
+    pub lwe_setting: concrete::lwe_params::LWEParams,
     pub with_ks: bool,
 }
 

--- a/src/zqz/tests.rs
+++ b/src/zqz/tests.rs
@@ -1,7 +1,8 @@
 use crate::PARAMS;
 use crate::zqz;
 use crate::zqz::keys::EncryptKey;
-use concrete::core_api::math::Random;
+use concrete_core::math::random::RandomGenerator;
+
 
 #[allow(unused_macros)]
 macro_rules! random_index {
@@ -9,9 +10,8 @@ macro_rules! random_index {
         if $max == 0 {
             (0 as usize)
         } else {
-            let mut rs = vec![0 as u32; 1];
-            Random::rng_uniform(&mut rs);
-            (rs[0] % ($max as u32)) as usize
+            let rs = RandomGenerator::new(None).random_uniform::<u32>();
+            (rs % ($max as u32)) as usize
         }
     }};
 }


### PR DESCRIPTION
Update of this demo to concrete v0.1.11:
- Switching the `crypto_api` members to its up-to-date counterparts in concrete v0.1.11
- Switching the random integer generation to `concrete-core`